### PR TITLE
Ensure use of kapitsa path when sourcing from another directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KAPITSA (v0.1.8)
+# KAPITSA (v0.1.9)
 
 <img src="https://repository-images.githubusercontent.com/239854510/065d3b80-6323-11ea-9b2f-806dbb0c592f" alt="Kapitsa logo" style="text-align:center"/>
 

--- a/kapitsa
+++ b/kapitsa
@@ -443,17 +443,22 @@ main() {
   # check settings to make sure env variable is set
   # and config file is set
   check_settings
-
+  
+  # Get the current directory of the script.
+  # https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel/56264110#56264110
+  [ -n "$ZSH_VERSION" ] && curr_dir=$(dirname "${(%):-%x}") || curr_dir=$(dirname "${BASH_SOURCE[0]:-$0}")
+  
   # create array of libraries to source
   local libraries
   libraries=('find_notebook_directories' 'find_in_notebook_source' 'find_recent_notebooks' 'find_in_notebook_tags' 'remove_cell_outputs' 'find_all_notebook_tags')
 
   # source libraries
   for i in "${libraries[@]}"; do
-    if [[ -r "./lib/$i.sh" ]] && [[ -f "./lib/$i.sh" ]]; then
+    shell_script="${curr_dir}/lib/$i.sh"
+    if [[ -r "$shell_script" ]] && [[ -f "$shell_script" ]]; then
       # shellcheck source=lib/find_notebooks.sh
       # shellcheck disable=SC1091
-      . "./lib/$i.sh"
+      . "$shell_script"
     fi
   done
 }


### PR DESCRIPTION
Fixes issue with sourcing from another directory. https://github.com/gitjeff05/kapitsa/issues/2

Inside the main function, `"./lib/$i.sh"` will resolve to the current directory instead of the kapitsa project root. As such, main cannot find the `./lib` directory. The solution is to use a technique to get the path of the sourced script:

https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel/56264110#56264110

