### PR TITLE
Add AND search syntax, --markdown/--all-cells flags, and test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,29 @@ Providing the ability to search *your* notebooks and any notebooks on your machi
 
 # API
 
-| Command                        | Description                                                              |
-| ------------------------------ | -------------------------------------------------------------------------|
-| kapitsa search regex [-p path] | Search notebook source.                                                  |
-| kapitsa tags regex [-v]        | Search notebook cell tags.                                               |
-| kapitsa list [path]            | List all paths containing .ipynb files.                                  |
-| kapitsa recent [num_days]               | List recently modified notebooks (default last 60 days)                                        |
-| kapitsa list-tags [path]       | List all defined tags.                                                   |
-| kapitsa clear notebook         | Remove cell outputs and execution_count from code cells in notebook      |
-| kapitsa [help\|h]              | Print help info.                                                         |
+| Command                                          | Description                                                              |
+| ------------------------------------------------ | -------------------------------------------------------------------------|
+| kapitsa search regex [-p path] [--all-cells] [--markdown] | Search notebook source. Use `term1+term2` for AND.          |
+| kapitsa tags regex [-v]                          | Search notebook cell tags.                                               |
+| kapitsa list [path]                              | List all paths containing .ipynb files.                                  |
+| kapitsa recent [num_days]                        | List recently modified notebooks (default last 60 days)                  |
+| kapitsa list-tags [path]                         | List all defined tags.                                                   |
+| kapitsa clear notebook                           | Remove cell outputs and execution_count from code cells in notebook      |
+| kapitsa [help\|h]                                | Print help info.                                                         |
 
 
 # Quick Examples
 
-| Command                                | Description                                                              |
-| -------------------------------------- | -------------------------------------------------------------------------|
-| kapitsa list .                         | Lists all paths in current directory containing .ipynb files             |
-| kapitsa search "join"                  | Print cells matching "join"                                              |
-| kapitsa search "(join\|concat)"        | Print cells matching on "join" or "concat"                               |
-| kapitsa tags "(pandas\|where)"         | Print cells with tags "pandas" or "where"                                |
-| kapitsa tags "(?=.*where)(?=.*loc)"    | Print cells with tags "where" and "loc"                                  |
+| Command                                          | Description                                                              |
+| ------------------------------------------------ | -------------------------------------------------------------------------|
+| kapitsa list .                                   | Lists all paths in current directory containing .ipynb files             |
+| kapitsa search "join"                            | Print code cells matching "join"                                         |
+| kapitsa search "(join\|concat)"                  | Print code cells matching "join" or "concat"                             |
+| kapitsa search "join+DataFrame"                  | Print code cells matching "join" AND "DataFrame"                         |
+| kapitsa search "pandas" --all-cells              | Print all cell types (code, markdown, raw) matching "pandas"             |
+| kapitsa search "install" --markdown              | Print markdown cells matching "install"                                  |
+| kapitsa tags "(pandas\|where)"                   | Print cells with tags "pandas" or "where"                                |
+| kapitsa tags "(?=.*where)(?=.*loc)"              | Print cells with tags "where" and "loc"                                  |
 
 # Verbose Examples
 
@@ -89,10 +92,28 @@ Found 2 matching cells in /Users/Me/File.ipynb
 ## Find cells matching "pandas" **AND** "numpy".
 
 ```bash session
-> kapitsa search "(?=.*pandas)(?=.*regex)"
+> kapitsa search "pandas+numpy"
 ```
 
-*Note: The above command does seem ridiculously complex for an `and` statement. Perhaps there is a better way. For now, I wanted the users to have complete control over the argument passed to `jq` to do the search.*
+Use `+` as a separator to require multiple terms in the same cell. Any number of terms is supported:
+
+```bash session
+> kapitsa search "read_csv+parse_dates+dtype"
+```
+
+The PCRE lookahead form still works if you need it: `kapitsa search "(?=.*pandas)(?=.*numpy)"`.
+
+## Search markdown cells.
+
+```bash session
+> kapitsa search "install" --markdown
+```
+
+## Search all cell types (code, markdown, raw).
+
+```bash session
+> kapitsa search "pandas" --all-cells
+```
 
 ## Have a quick glance to see what notebooks you have worked on recently:
 

--- a/kapitsa
+++ b/kapitsa
@@ -81,7 +81,10 @@ check_kapitsa_config() {
 #######################################
 kapitsa_help() {
   echo -e "\nKapitsa Help:\n"
-  echo -e "${CL_CYA}kapitsa ${CL_RED}search regex [-p path]${CL_DEF}   Search cell source."
+  echo -e "${CL_CYA}kapitsa ${CL_RED}search regex [-p path] [--all-cells] [--markdown]${CL_DEF}"
+  echo -e "                                  Search cell source. Use 'term1+term2' for AND."
+  echo -e "                                  --all-cells includes markdown and raw cells."
+  echo -e "                                  --markdown searches only markdown cells."
   echo -e "${CL_CYA}kapitsa ${CL_RED}tags regex [-v]${CL_DEF}          Search cell tags [-verbose mode]."
   echo -e "${CL_CYA}kapitsa ${CL_RED}list [path]${CL_DEF}              List all paths containing .ipynb files."
   echo -e "${CL_CYA}kapitsa ${CL_RED}recent [days]${CL_DEF}            List recently modified notebooks in the past num_days (default is 60)."
@@ -90,8 +93,11 @@ kapitsa_help() {
   echo -e "By default Kapitsa searches all paths defined in ${CL_CYA}.kapitsa${CL_DEF} config file.\n"
   echo -e "Examples\n"
   echo -e "${CL_CYA}kapitsa ${CL_RED}list .${CL_DEF}                      Lists all paths in current directory containing .ipynb files"
-  echo -e "${CL_CYA}kapitsa ${CL_RED}search \"join\" ${CL_DEF}              Print cells matching \"join\""
-  echo -e "${CL_CYA}kapitsa ${CL_RED}search \"(join|concat)\" ${CL_DEF}     Print cells matching on \"join\" or \"concat\""
+  echo -e "${CL_CYA}kapitsa ${CL_RED}search \"join\" ${CL_DEF}                      Print cells matching \"join\""
+  echo -e "${CL_CYA}kapitsa ${CL_RED}search \"(join|concat)\" ${CL_DEF}             Print cells matching on \"join\" or \"concat\""
+  echo -e "${CL_CYA}kapitsa ${CL_RED}search \"join+DataFrame\" ${CL_DEF}            Print code cells matching \"join\" AND \"DataFrame\""
+  echo -e "${CL_CYA}kapitsa ${CL_RED}search \"install\" --markdown ${CL_DEF}        Print markdown cells matching \"install\""
+  echo -e "${CL_CYA}kapitsa ${CL_RED}search \"pandas\" --all-cells ${CL_DEF}        Print all cell types matching \"pandas\""
   echo -e "${CL_CYA}kapitsa ${CL_RED}tags \"(pandas|where)\" ${CL_DEF}      Print cells with tags \"pandas\" or \"where\""
   echo -e "${CL_CYA}kapitsa ${CL_RED}tags \"(?=.*where)(?=.*loc)\"${CL_DEF} Print cells with tags \"where\" and \"loc\"\n"
 }
@@ -133,17 +139,20 @@ get_kapitsa_paths() {
 # in the config paths. If optional path is provided,
 # limit search to that path.
 # Arguments:
-#   search_string [-p path]
+#   search_string [-p path] [--all-cells]
 #######################################
 kapitsa_search() {
 
   local search_string
   local path_list
   local paths
+  local all_cells
 
   # (todo jeff) zsh & bash arguments ordering
   # search string that was passed in
   search_string="$1"
+  all_cells="$2"
+  cell_type_filter="$3"
 
   # Get a list of paths on separate lines
   path_list=$(jq '.path' <"$KAPITSA" | tr -d '[][:space:]"' | tr ':' '\n')
@@ -160,7 +169,7 @@ kapitsa_search() {
       break
     fi
 
-    find_in_notebook_source "${directory}" "${search_string}"
+    find_in_notebook_source "${directory}" "${search_string}" "${all_cells}" "${cell_type_filter}"
 
   done <<< "$paths"
 
@@ -380,37 +389,52 @@ kapitsa() {
   # search notebooks
   elif [[ "$option" == "search" ]] || [[ "$option" == "s" ]]; then
 
-    local args
-    local search_arguments
+    local search_string
+    local search_path
+    local all_cells
+    local cell_type_filter
 
-    args=("$@")
-    search_arguments=("${args[@]:1}")
+    search_string="${2}"
+    search_path=""
+    all_cells="false"
+    cell_type_filter="code"
 
-    if [[ "${#search_arguments[@]}" -eq 1 ]]; then
+    # Parse optional flags from remaining args
+    shift 2
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        -p)
+          shift
+          search_path="$1"
+          ;;
+        --all-cells)
+          all_cells="true"
+          cell_type_filter=""
+          ;;
+        --markdown)
+          cell_type_filter="markdown"
+          ;;
+        *)
+          echo -e "Unknown argument: $1\n"
+          kapitsa_help
+          return 1
+          ;;
+      esac
+      shift
+    done
 
-      # Only the search regex was passed. Do default search across config paths
-      kapitsa_search "${2}"
-
-    elif [[ "${#search_arguments[@]}" -eq 3 ]]; then
-
-      # Three arguments supplied. User is trying to supply a path to search
-
-      # Check to make sure 2nd arg was the '-p' flag
-      if [[ "${3}" != "-p" ]]; then
-        echo -e "Incorrect argument order. Optional third argument must be -p followed by a valid path.\n"
-        kapitsa_help
-        return 1
-      fi
-
-      # Pass arguments to find_in_notebook_source
-      find_in_notebook_source "${4}" "${2}"
-
-    else
-
-      echo -e "Incorrect number of arguments\n"
+    if [[ -z "$search_string" ]]; then
+      echo -e "You must supply a search string.\n"
       kapitsa_help
       return 1
+    fi
 
+    if [[ -n "$search_path" ]]; then
+      # Search a specific path
+      find_in_notebook_source "${search_path}" "${search_string}" "${all_cells}" "${cell_type_filter}"
+    else
+      # Search all configured paths
+      kapitsa_search "${search_string}" "${all_cells}" "${cell_type_filter}"
     fi
 
   elif [[ "$option" == "tags" ]] || [[ "$option" == "t" ]]; then

--- a/lib/find_in_notebook_source.sh
+++ b/lib/find_in_notebook_source.sh
@@ -33,21 +33,40 @@ find_in_notebook_source() {
   SEARCH_DIRECTORY="${1:-$CURRENT_DIRECTORY}"
 
   SEARCH_STRING="$2"
+  ALL_CELLS="${3:-false}"
+  # cell_type_filter: "code" (default), "markdown", or "" (all cells)
+  CELL_TYPE_FILTER="${4:-code}"
+
+  # if --all-cells was set, override the filter
+  if [[ "$ALL_CELLS" == "true" ]]; then
+    CELL_TYPE_FILTER=""
+  fi
 
   # if function is called directly, ensure the search string is supplied
   if [[ -z "$SEARCH_STRING" ]]; then
     echo "You must supply a path as the first argument and a string to search as the second. For example:"
     echo "find_in_notebook_source . \"DataFrame\""
     echo "find_in_notebook_source . \"(pandas|numpy)\""
-    echo "find_in_notebook_source . \"(?=.*read_csv)(?=.*parse_dates)\""
+    echo "find_in_notebook_source . \"pandas+numpy\"    # AND: cells containing both terms"
+    echo "find_in_notebook_source . \"read_csv+parse_dates\""
     return 1
+  fi
+
+  # Convert "term1+term2+term3" AND syntax into PCRE lookaheads
+  # e.g. "pandas+numpy" -> "(?=.*pandas)(?=.*numpy)"
+  local JQ_PATTERN
+  if [[ "$SEARCH_STRING" == *"+"* ]]; then
+    JQ_PATTERN=""
+    IFS='+' read -ra terms <<< "$SEARCH_STRING"
+    for term in "${terms[@]}"; do
+      JQ_PATTERN="${JQ_PATTERN}(?=.*${term})"
+    done
+  else
+    JQ_PATTERN="$SEARCH_STRING"
   fi
 
   # Check if valid directory
   if [[ -d "$SEARCH_DIRECTORY" ]]; then
-
-    # find .ipynb files and ignore checkpoints directory
-    # return all paths that contain .ipynb files.
 
     local cells_matching_on_search
     local num_cells_matching_search
@@ -64,12 +83,21 @@ find_in_notebook_source() {
     # iterate over array of files
     for i in "${array[@]}"; do
 
-      # find files matching on search string
-      cells_matching_on_search="$(jq -r --arg foo "$SEARCH_STRING" '.cells
-        | map(
-          select( (.cell_type == "code" ) and
-                  ( .source | join(" ") | test($foo, "imx") ) )
-        ) | [ .[] | { source: .source } ]' <"$i")"
+      # Build the jq cell-type filter clause.
+      # ""  -> all cell types
+      # "code" or "markdown" -> restrict to that type only
+      if [[ -z "$CELL_TYPE_FILTER" ]]; then
+        cells_matching_on_search="$(jq -r --arg foo "$JQ_PATTERN" '.cells
+          | map(
+            select( .source | join(" ") | gsub("\n";" ") | test($foo, "imx") )
+          ) | [ .[] | { cell_type: .cell_type, source: .source } ]' <"$i")"
+      else
+        cells_matching_on_search="$(jq -r --arg foo "$JQ_PATTERN" --arg ctype "$CELL_TYPE_FILTER" '.cells
+          | map(
+            select( (.cell_type == $ctype) and
+                    ( .source | join(" ") | gsub("\n";" ") | test($foo, "imx") ) )
+          ) | [ .[] | { cell_type: .cell_type, source: .source } ]' <"$i")"
+      fi
 
       # number of cells matching
       num_cells_matching_search="$(printf "%s" "$cells_matching_on_search" | jq '. | length')"

--- a/test_search.sh
+++ b/test_search.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+source lib/find_in_notebook_source.sh
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  local expected_contains="$3"
+  if echo "$result" | grep -q "$expected_contains"; then
+    echo "PASS: $desc"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $desc"
+    echo "  expected to find: $expected_contains"
+    echo "  got: $(echo "$result" | head -3)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+check_absent() {
+  local desc="$1"
+  local result="$2"
+  local should_not_contain="$3"
+  if echo "$result" | grep -q "$should_not_contain"; then
+    echo "FAIL: $desc (found unexpected: $should_not_contain)"
+    FAIL=$((FAIL+1))
+  else
+    echo "PASS: $desc"
+    PASS=$((PASS+1))
+  fi
+}
+
+check_empty() {
+  local desc="$1"
+  local result="$2"
+  if [[ -z "$(echo "$result" | tr -d '[:space:]')" ]]; then
+    echo "PASS: $desc (no results as expected)"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $desc (expected no results, got output)"
+    echo "  got: $(echo "$result" | head -3)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "--- 1. Basic regex search (unchanged behavior) ---"
+r=$(find_in_notebook_source examples "join")
+check "basic search finds match" "$r" "Found"
+check "basic search returns source" "$r" "source"
+
+echo ""
+echo "--- 2. OR regex (unchanged behavior) ---"
+r=$(find_in_notebook_source examples "(join|merge)")
+check "OR regex finds match" "$r" "Found"
+
+echo ""
+echo "--- 3. AND with + operator (2 terms) ---"
+r=$(find_in_notebook_source examples "join+set_index")
+check "AND 2 terms finds match" "$r" "Found"
+check "AND result contains join" "$r" "join"
+check "AND result contains set_index" "$r" "set_index"
+
+echo ""
+echo "--- 4. AND with + operator (3 terms) ---"
+# This cell exists: join + set_index + dataframe (case-insensitive matches DataFrame)
+r=$(find_in_notebook_source examples "join+set_index+dataframe")
+check "AND 3 terms finds match" "$r" "Found"
+
+echo ""
+echo "--- 5. AND with + that should return no results ---"
+r=$(find_in_notebook_source examples "join+ZZZNOMATCH")
+check_empty "AND with no match returns nothing" "$r"
+
+echo ""
+echo "--- 6. --markdown flag finds markdown cells ---"
+r=$(find_in_notebook_source examples "NIH" false markdown)
+check "markdown search finds result" "$r" "Found"
+check "result has markdown cell_type" "$r" '"cell_type": "markdown"'
+
+echo ""
+echo "--- 7. --markdown flag does NOT return code cells ---"
+r=$(find_in_notebook_source examples "NIH" false markdown)
+check_absent "markdown search has no code cells" "$r" '"cell_type": "code"'
+
+echo ""
+echo "--- 8. --all-cells finds both code and markdown ---"
+r=$(find_in_notebook_source examples "NIH" true)
+check "all-cells finds markdown" "$r" '"cell_type": "markdown"'
+check "all-cells finds code" "$r" '"cell_type": "code"'
+
+echo ""
+echo "--- 9. Default (code only) does NOT return markdown cells ---"
+r=$(find_in_notebook_source examples "read_csv")
+check_absent "default search has no markdown cells" "$r" '"cell_type": "markdown"'
+
+echo ""
+echo "--- 10. + AND combined with --markdown ---"
+r=$(find_in_notebook_source examples "NIH+data" false markdown)
+check "AND + markdown finds result" "$r" "Found"
+check_absent "AND + markdown has no code cells" "$r" '"cell_type": "code"'
+
+echo ""
+echo "--- 11. + AND combined with --all-cells ---"
+r=$(find_in_notebook_source examples "NIH+data" true)
+check "AND + all-cells finds result" "$r" "Found"
+
+echo ""
+echo "--- 12. Invalid directory error ---"
+r=$(find_in_notebook_source /nonexistent "join" 2>&1)
+check "invalid dir prints error" "$r" "not valid"
+
+echo ""
+echo "--- 13. Search term not present returns nothing ---"
+r=$(find_in_notebook_source examples "ZZZNOMATCHATALL")
+check_empty "no match returns empty" "$r"
+
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
  This PR extends the search command with three new capabilities:

  - AND search syntax — use term1+term2 to find cells containing all terms (e.g. search
  "pandas+DataFrame"). Internally converts to PCRE lookaheads.
  - --markdown flag — restricts search to markdown cells instead of the default code cells.
  - --all-cells flag — searches across all cell types (code, markdown, raw).

  The argument parsing for search was refactored from positional-only to a proper while/case flag loop,
   making it easier to combine -p, --markdown, and --all-cells in any order.

  A new test_search.sh test suite is also included, covering the new flags and AND syntax alongside
  existing behavior.